### PR TITLE
Create a Github action to build the website

### DIFF
--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -1,0 +1,34 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Set a branch to deploy
+  pull_request:
+
+jobs:
+  build-site:
+    runs-on: ubuntu-22.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true # Incase we subrepo stuff in
+          fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: "0.119.0"
+          extended: true
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Upload output artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: website-build.zip
+          path: ./public
+          if-no-files-found: error

--- a/.github/workflows/hugo-build.yml
+++ b/.github/workflows/hugo-build.yml
@@ -17,6 +17,9 @@ jobs:
           submodules: true # Incase we subrepo stuff in
           fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
 
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y asciidoctor && sudo apt-get purge
+
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:


### PR DESCRIPTION
Working towards automating things, this adds a github action to run on PR's and merges to create an artefact of the website build output.

Intended to help with testing and deployment.

Was thinking about making a "release" deployment one that makes a new release tag on merges into `main`, but as the site is ~0.5GiB unsure if that's desired? 