### PR TITLE
Information about second port on the UART adapter

### DIFF
--- a/content/documentation/PineTab2/Development/UART_adapter.adoc
+++ b/content/documentation/PineTab2/Development/UART_adapter.adoc
@@ -14,7 +14,7 @@ image:/documentation/PineTab2/PineTab2_USB_UARTv2.jpg[The UART adapter,title="Th
 The USB-C UART adapter can be connected to the PineTab2 to debug boot issues at the early boot:
 
 * Plug the adapter face-up in the USB-C port furthest away from the power button. If all the lights are lit, you have the wrong port: only the green light should be lit when you first plug it in.
-* Plug USB-C cable into the port on the adapter marked "DEBUG"
+* Plug USB-C cable into the port on the adapter marked "DEBUG" (the other port can be used as a power delivery passthrough so you can charge and debut at the same time)
 * Open a terminal window
 * Install ''minicom'' or ''screen'' via your distribution's package manager, if you don't have it installed already
 * Connect via minicom using `sudo minicom -D /dev/ttyUSB0 -b 1500000` or via screen using `sudo screen /dev/ttyUSB0 1500000`
@@ -23,3 +23,4 @@ The USB-C UART adapter can be connected to the PineTab2 to debug boot issues at 
 *** `sudo systemctl mask brltty-udev.service`
 *** `sudo systemctl stop brltty.service`
 *** `sudo systemctl mask brltty.service`
+


### PR DESCRIPTION
Added a parenthesis on `UART_adapter.adoc` explaining that the other port in the adapter can be used as a passthrough to charge the device while debugging.