### PR TITLE
Change "Twitter" to "X (Twitter)"

### DIFF
--- a/themes/pinetheme/layouts/partials/footer.html
+++ b/themes/pinetheme/layouts/partials/footer.html
@@ -17,7 +17,7 @@
             <div class="col">
                 <h2>News</h2>
                 <ul id="menu-pine-store" class="menu">
-                    <li><a href="https://twitter.com/thepine64">Twitter</a></li>
+                    <li><a href="https://twitter.com/thepine64">X (Twitter)</a></li>
                     <li><a href="https://fosstodon.org/@PINE64">Mastodon</a></li>
                     <li><a href="https://t.me/PINE64_News">Telegram News</a></li>
                 </ul>


### PR DESCRIPTION
It's been rebranded to X, but it's still commonly called Twitter, so it's probably worth mentioning both.