### PR TITLE
Fixed a redirect issue with the search bar

### DIFF
--- a/themes/pinetheme/layouts/partials/header.html
+++ b/themes/pinetheme/layouts/partials/header.html
@@ -17,7 +17,7 @@
 
         <!-- Search -->
         <div id="search">
-            <form action="/search" method="GET">
+            <form action="/search/" method="GET">
                 <input type="search" name="q" id="search-query" placeholder="Search...."><button type="submit" aria-label="Search button">
                     <svg width="22" height="14" viewBox="0 -0.5 21 21" xmlns="http://www.w3.org/2000/svg">
                         <path d="m5.94 12.929 1.485 1.414L1.485 20 0 18.586l5.94-5.657ZM13.65 12C10.755 12 8.4 9.757 8.4 7s2.355-5 5.25-5 5.25 2.243 5.25 5-2.355 5-5.25 5Zm0-12C9.59 0 6.3 3.134 6.3 7s3.29 7 7.35 7S21 10.866 21 7s-3.29-7-7.35-7Z" fill="#fff" fill-rule="evenodd"/>


### PR DESCRIPTION
When I used the search bar, it redirected me from `/search?q=asd` to `/search/` dropping the search string
![image](https://github.com/pine64/website/assets/7405480/47da6792-51b3-40fe-9371-66f5a6ca0b17)

Changed the `action` of the form to `/search/` to fix this
![image](https://github.com/pine64/website/assets/7405480/2f3211eb-f5fc-4adf-af32-e0a7e4bdea5a)
