### PR TITLE
link to official NixOS wiki

### DIFF
--- a/content/documentation/Pinebook_Pro/Software/Releases.adoc
+++ b/content/documentation/Pinebook_Pro/Software/Releases.adoc
@@ -527,7 +527,7 @@ You can follow the ongoing discussion about NixOS on the https://forum.pine64.or
 
 *Installation*
 
-* This is instructions to install NixOS on the Pinebook Pro: https://nixos.wiki/wiki/NixOS_on_ARM/PINE64_Pinebook_Pro
+* This is instructions to install NixOS on the Pinebook Pro: https://wiki.nixos.org/wiki/NixOS_on_ARM/PINE64_Pinebook_Pro
 * Please pull the latest https://github.com/samueldr/wip-pinebook-pro[samueldr's repository ] from the project's GitHub.
 
 === SkiffOS

--- a/content/documentation/ROCKPro64/Software/Releases.adoc
+++ b/content/documentation/ROCKPro64/Software/Releases.adoc
@@ -144,7 +144,7 @@ Download:
 
 image:/documentation/images/NixOS.webp[width=100]
 
-*NixOS* is a Linux distribution built on top of the Nix package manager using declarative configuration to allow reliable system upgrades. More information can be found on the https://nixos.wiki/wiki/NixOS_on_ARM/PINE64_ROCKPro64[NixOS wiki].
+*NixOS* is a Linux distribution built on top of the Nix package manager using declarative configuration to allow reliable system upgrades. More information can be found on the https://wiki.nixos.org/wiki/NixOS_on_ARM/PINE64_ROCKPro64[NixOS wiki].
 
 Download:
 


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org
ref: NixOS/foundation#113