### PR TITLE
Fixed OX64/OZ64 Documentation Typos

### DIFF
--- a/content/devices/oz64.adoc
+++ b/content/devices/oz64.adoc
@@ -10,7 +10,7 @@ images:
 
 == The Oz64
 
-The Oz64 is a low cost single-board computer based on the Sophgo SG2000 SoC with dual T-Head C906 64-bit RISC-V cores, an ARM Cortex A53 64-bit RISC CPU core and an 8051 8-bit core supported by 512 MB of embedded DRAM memory, with WiFi and Bluetooh radio interfaces. 
+The Oz64 is a low cost single-board computer based on the Sophgo SG2000 SoC with dual T-Head C906 64-bit RISC-V cores, an ARM Cortex A53 64-bit RISC CPU core and an 8051 8-bit core supported by 512 MB of embedded DRAM memory, with WiFi and Bluetooth radio interfaces. 
 
 The Oz64 SBC comes in a model-B form-factor, has a microSD card slot, an eMMC plugin connector, an USB 2.0 Type-A host port, and many other peripheral interfaces for makers to integrate with sensors and other devices.
 

--- a/content/documentation/Ox64/_index.adoc
+++ b/content/documentation/Ox64/_index.adoc
@@ -9,7 +9,7 @@ menu:
     weight: 
 ---
 
-The *Ox64* is a RISC-V based single-board computer based on the Bouffalo Lab BL808 RISC-V SoC with C906 64-bit and E907/E902 32-bit CPU cores supported by 64 MB of embedded PSRAM memory, and with built-in WiFi, Bluetooh and Zigbee radio interfaces. The Ox64 comes in a breadboard-friendly form-factor, has a microSD card slot, a USB 2.0 Type-C port, and many other peripheral interfaces for makers to integrate with sensors and other devices.
+The *Ox64* is a RISC-V based single-board computer based on the Bouffalo Lab BL808 RISC-V SoC with C906 64-bit and E907/E902 32-bit CPU cores supported by 64 MB of embedded PSRAM memory, and with built-in WiFi, Bluetooth and Zigbee radio interfaces. The Ox64 comes in a breadboard-friendly form-factor, has a microSD card slot, a USB 2.0 Type-C port, and many other peripheral interfaces for makers to integrate with sensors and other devices.
 
 image:/documentation/Ox64/images/Ox64_board.jpg[The Ox64,title="The Ox64", 100]
 

--- a/content/documentation/Oz64/_index.adoc
+++ b/content/documentation/Oz64/_index.adoc
@@ -9,7 +9,7 @@ menu:
     weight: 
 ---
 
-The *Oz64* is a low cost single-board computer based on the Sophgo SG2000 SoC with dual T-Head C906 64-bit RISC-V cores, an ARM Cortex A53 64-bit RISC CPU core and an 8051 8-bit core supported by 512 MB of embedded DRAM memory, with WiFi and Bluetooh radio interfaces. 
+The *Oz64* is a low cost single-board computer based on the Sophgo SG2000 SoC with dual T-Head C906 64-bit RISC-V cores, an ARM Cortex A53 64-bit RISC CPU core and an 8051 8-bit core supported by 512 MB of embedded DRAM memory, with WiFi and Bluetooth radio interfaces. 
 
 The Oz64 SBC comes in a model-B form-factor, has a microSD card slot, an eMMC plugin connector, an USB 2.0 Type-A host port, and many other peripheral interfaces for makers to integrate with sensors and other devices. 
 


### PR DESCRIPTION
**Purpose**
This pull request includes 1 commit changing 3 instances in the websites documentation, found on both the OX64 and OZ64 pages, which spelled `Bluetooth` as `Bluetooh`.

**Scope**
This pull request only seeks to fix those instances and does not include additional spell or grammar checking.