### PR TITLE
Fix link to Quick Start guide

### DIFF
--- a/content/documentation/PineTime/Further_information/Datasheets,_schematics_and_certifications.md
+++ b/content/documentation/PineTime/Further_information/Datasheets,_schematics_and_certifications.md
@@ -66,4 +66,4 @@ Sensor:
 
 ## Manuals
 
-* https://wiki.pine64.org/wiki/File:PineTime Quick Start Guide.pdf[PineTime Quick Start Guide]
+* [PineTime Quick Start Guide](https://wiki.pine64.org/wiki/File:PineTime_Quick_Start_Guide.pdf)


### PR DESCRIPTION
The link to the quick start guide for the PineTime is malformed and doesn't work just by clicking on it: https://pine64.org/documentation/PineTime/Further_information/Datasheets_schematics_and_certifications/#manuals

This PR fixes the Markdown formatting.