### PR TITLE
Update Model-A.adoc Input 12V not 5V

### DIFF
--- a/content/documentation/SOQuartz/Baseboards/Model-A.adoc
+++ b/content/documentation/SOQuartz/Baseboards/Model-A.adoc
@@ -12,7 +12,7 @@ menu:
 {{< figure src="/documentation/SOQuartz/images/SOQuartz_model-A_baseboard.jpg" title="SOQuartz Model-A Baseboard" width="400" >}}
 
 * Model "A" Baseboard Dimensions: 133mm x 80mm x 19mm
-* Input Power: DC 5V @ 3A 3.5OD/1.35ID (IEC 60130-10 Type H) Barrel DC Jack connector
+* Input Power: DC 12V @ 3A 5.5OD/2.1ID (IEC 60130-10 Type A) Barrel DC Jack connector
 
 == Storage
 


### PR DESCRIPTION
If I read https://wiki.pine64.org/wiki/SOQuartz#SOQuartz_Model-A_Baseboard_Features
and my physical test, model A take 12V input not 5V