### PR TITLE
Remove trailing '='s from InfiniTime_weather.md

### DIFF
--- a/content/documentation/PineTime/Software/InfiniTime_weather.md
+++ b/content/documentation/PineTime/Software/InfiniTime_weather.md
@@ -11,17 +11,17 @@ menu:
 
 Infinitime features a weather subsystem which stores weather data on the watch in a timeline which can be queried by apps or watchfaces. It can store many different types of data (see [here](https://github.com/InfiniTimeOrg/InfiniTime/blob/main/src/components/ble/weather/WeatherData.h)) and each entry includes a timestamp and an expiry time. When entries expire they are removed from the timeline automatically.
 
-## Sending weather data to the watch ==
+## Sending weather data to the watch
 
 Weather data must be sent to the watch via a companion app. Currently, [ITD](https://gitea.elara.ws/Elara6331/itd) and [Gadgetbridge](https://www.gadgetbridge.org)  have this functionality implemented. 
 
-### ITD ===
+### ITD
 ITD is the easiest option as the feature simply needs enabling in the config file with a location specified. It uses data from MET.no and provides one hour of data at a time.
 
-### Gadgetbridge ===
+### Gadgetbridge
 Gadgetbridge is slightly more difficult to set up as it requires a separate app to fetch the weather data. Details are available on the [Gadgetbridge website](https://gadgetbridge.org/basics/features/weather/).
 
-## Displaying weather data ==
+## Displaying weather data
 
 Currently there are 2 ways to display weather data on the watch, a debug app  which is disabled by default, and the PineTimeStyle watchface. To enable it, press and hold on the watch face, tap the settings icon and enable weather.
 


### PR DESCRIPTION
These titles oddly had trailing `=`s.  I removed them.