### PR TITLE
add pinenote disassembly and parts replacement page

### DIFF
--- a/content/documentation/PineNote/Further_information/Disassembly_and_parts_replacement.md
+++ b/content/documentation/PineNote/Further_information/Disassembly_and_parts_replacement.md
@@ -1,19 +1,21 @@
+---
+title: "Disassembly and Parts Replacement"
+draft: false
+menu:
+  docs:
+    title:
+    parent: "PineNote/Further_information"
+    identifier: "PineNote/Further_information/Disassembly_and_parts_replacement"
+    weight: 7
+---
 
-+++
-title = "Disassembly and Parts Replacement"
-draft = false
-weight = 70
-[menu.docs]
-  parent = "PineNote/Further_information"
-  identifier = "pinenote-disassembly-parts"
-+++
-
-## Battery Replacement
+## Battery replacement
 
 See writeup on the wiki: https://wiki.pine64.org/wiki/PineNote/Battery_Replacement
 
 <!-- TODO: reproduce full guide here once wiki content is confirmed stable -->
-## USB-C Sideboard Replacement
+
+## USB-C Sideboard replacement
 
 The USB-C Sideboard is one of the few replacement parts available from the Pine64 Store: https://pine64.com/product/pinepmote-usb-c-side-board/
 

--- a/content/documentation/PineNote/Further_information/pinenote-dissasembly-parts.md
+++ b/content/documentation/PineNote/Further_information/pinenote-dissasembly-parts.md
@@ -12,18 +12,17 @@ weight = 70
 
 See writeup on the wiki: https://wiki.pine64.org/wiki/PineNote/Battery_Replacement
 
-- This should maybe be reproduced here in full.
-
+<!-- TODO: reproduce full guide here once wiki content is confirmed stable -->
 ## USB-C Sideboard Replacement
 
-The USB-C Sideboard is one of the few replacement parts available from the Pine64 Store, though the URL and product title are spelled uniquely incorrectly: https://pine64.com/product/pinepmote-usb-c-side-board/ .
+The USB-C Sideboard is one of the few replacement parts available from the Pine64 Store: https://pine64.com/product/pinepmote-usb-c-side-board/
 
 1. Starting at the top of the device, and continuing around the top corners and down the sides, pry the back case away from the face of the device. A pry tool may be useful, though it has been reported possible to do with bare fingers. Like any plastic-clipped case, it requires gentleness while at other times significant force to remove the back panel. See Battery Replacement guide above for another description.
 2. Flip the device over and locate the USB-C Sideboard on the very bottom. It looks just like the replacement!
-3. It is connected by a small ribbon, gently lift the retaining flap opposite the ribbon to release the ribbon cable, and gently slide it out.
-4. Two shallow phillips screws secure the sideboard, unscrew them, replace the sideboard with new one, re-screw in place. Note a very pointy screwdriver will not work, the screw does not have much depth to it and requires a relatively blunt screwdriver head.
+3. It is connected by a small ribbon, gently lift the retaining flap on the connector to release the ribbon cable, and slide the cable out.
+4. Two shallow phillips screws secure the sideboard, unscrew them, replace the sideboard with new one, screw the replacement in place. Note a very pointy screwdriver will not work, the screw does not have much depth to it and requires a relatively blunt screwdriver head.
 5. Gently replace the ribbon and press retaining flap down to secure the ribbon.
-6. Test the new USB-C by connecting a cable to power or data and make sure the tablet responds _before replacing the back case_
+6. Test the new USB-C by connecting a cable to power or data and make sure the tablet responds _before replacing the back case_.
 7. Without putting any pressure on the new USB-C connection, line it up with the bottom of the device and firmly press in bottom edge and corners of the device back into the casing with audible click.
 8. Firm pinching with your whole hand up the edge of the case should easily click the entire case back into place.
 9. Test that the power/sleep button functions and the case is flush everywhere.

--- a/content/documentation/PineNote/Further_information/pinenote-dissasembly-parts.md
+++ b/content/documentation/PineNote/Further_information/pinenote-dissasembly-parts.md
@@ -1,0 +1,29 @@
+
++++
+title = "Disassembly and Parts Replacement"
+draft = false
+weight = 70
+[menu.docs]
+  parent = "PineNote/Further_information"
+  identifier = "pinenote-disassembly-parts"
++++
+
+## Battery Replacement
+
+See writeup on the wiki: https://wiki.pine64.org/wiki/PineNote/Battery_Replacement
+
+- This should maybe be reproduced here in full.
+
+## USB-C Sideboard Replacement
+
+The USB-C Sideboard is one of the few replacement parts available from the Pine64 Store, though the URL and product title are spelled uniquely incorrectly: https://pine64.com/product/pinepmote-usb-c-side-board/ .
+
+1. Starting at the top of the device, and continuing around the top corners and down the sides, pry the back case away from the face of the device. A pry tool may be useful, though it has been reported possible to do with bare fingers. Like any plastic-clipped case, it requires gentleness while at other times significant force to remove the back panel. See Battery Replacement guide above for another description.
+2. Flip the device over and locate the USB-C Sideboard on the very bottom. It looks just like the replacement!
+3. It is connected by a small ribbon, gently lift the retaining flap opposite the ribbon to release the ribbon cable, and gently slide it out.
+4. Two shallow phillips screws secure the sideboard, unscrew them, replace the sideboard with new one, re-screw in place. Note a very pointy screwdriver will not work, the screw does not have much depth to it and requires a relatively blunt screwdriver head.
+5. Gently replace the ribbon and press retaining flap down to secure the ribbon.
+6. Test the new USB-C by connecting a cable to power or data and make sure the tablet responds _before replacing the back case_
+7. Without putting any pressure on the new USB-C connection, line it up with the bottom of the device and firmly press in bottom edge and corners of the device back into the casing with audible click.
+8. Firm pinching with your whole hand up the edge of the case should easily click the entire case back into place.
+9. Test that the power/sleep button functions and the case is flush everywhere.


### PR DESCRIPTION
new page in pinenote/further_information/ called pinenote-disassembly-parts with simple description for removing the pinenote case and replacing the usb-c sideboard, while linking to the battery replacement guide in the wiki to make it easier to find.